### PR TITLE
changes to enable proper single request sampling

### DIFF
--- a/package/gs/gs/Makefile
+++ b/package/gs/gs/Makefile
@@ -11,7 +11,7 @@ define Package/gs
   SECTION:=examples
   CATEGORY:=Examples
   TITLE:=gs control application
-  DEPENDS:=+libmodbus
+  DEPENDS:=+libmodbus +libgpiod
 endef
 
 define Package/gs/description

--- a/target/linux/imx6ull/dts/gs.dts
+++ b/target/linux/imx6ull/dts/gs.dts
@@ -494,5 +494,15 @@
 		channel@1 {
 			reg = <1>;
 		};
+
+		channel@4 {
+			reg = <4>;
+            ti,datarate=<7>;
+		};
+
+		channel@5 {
+			reg = <5>;
+            ti,datarate=<7>;
+		};
 	};
 };

--- a/target/linux/imx6ull/dts/gs.dts
+++ b/target/linux/imx6ull/dts/gs.dts
@@ -498,11 +498,13 @@
 		channel@4 {
 			reg = <4>;
             ti,datarate=<7>;
+            ti,gain = <0>;
 		};
 
 		channel@5 {
 			reg = <5>;
             ti,datarate=<7>;
+            ti,gain = <0>;
 		};
 	};
 };

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -19,7 +19,7 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
 -		conv_time += conv_time / 10; /* 10% internal clock inaccuracy */
 -		usleep_range(conv_time, conv_time + 1);
-+		conv_time += conv_time / 4; /* 20% internal clock inaccuracy */
++		conv_time += conv_time / 2; /* 50% internal clock inaccuracy */
 +		usleep_range(conv_time, conv_time + conv_time/10);
  		data->conv_invalid = false;
  	}

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -38,14 +38,15 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  		ret = regmap_write(data->regmap, ADS1015_CFG_REG, cfg);
  		if (ret)
  			return ret;
-@@ -375,8 +379,8 @@ int ads1015_get_adc_result(struct ads101
+@@ -375,8 +379,9 @@ int ads1015_get_adc_result(struct ads101
  		dr_old = (old & ADS1015_CFG_DR_MASK) >> ADS1015_CFG_DR_SHIFT;
  		conv_time = DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr_old]);
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
 -		conv_time += conv_time / 10; /* 10% internal clock inaccuracy */
 -		usleep_range(conv_time, conv_time + 1);
-+		conv_time += conv_time / 2; /* 50% internal clock inaccuracy */
-+		usleep_range(conv_time, conv_time + conv_time/10);
++		conv_time += conv_time / 10; /* 50% internal clock inaccuracy */
++		conv_time = DIV_ROUND_UP(conv_time, USEC_PER_MSEC);
++		msleep(conv_time);
  		data->conv_invalid = false;
  	}
  

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -19,7 +19,7 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
 -		conv_time += conv_time / 10; /* 10% internal clock inaccuracy */
 -		usleep_range(conv_time, conv_time + 1);
-+		conv_time += conv_time / 5; /* 20% internal clock inaccuracy */
++		conv_time += conv_time / 4; /* 20% internal clock inaccuracy */
 +		usleep_range(conv_time, conv_time + conv_time/10);
  		data->conv_invalid = false;
  	}

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -13,7 +13,32 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
 ===================================================================
 --- linux-5.4.168.orig/drivers/iio/adc/ti-ads1015.c
 +++ linux-5.4.168/drivers/iio/adc/ti-ads1015.c
-@@ -375,8 +375,8 @@ int ads1015_get_adc_result(struct ads101
+@@ -46,6 +46,7 @@
+ #define ADS1015_CFG_MOD_SHIFT	8
+ #define ADS1015_CFG_PGA_SHIFT	9
+ #define ADS1015_CFG_MUX_SHIFT	12
++#define ADS1015_CFG_OS_SHIFT	15
+ 
+ #define ADS1015_CFG_COMP_QUE_MASK	GENMASK(1, 0)
+ #define ADS1015_CFG_COMP_LAT_MASK	BIT(2)
+@@ -55,6 +56,7 @@
+ #define ADS1015_CFG_MOD_MASK	BIT(8)
+ #define ADS1015_CFG_PGA_MASK	GENMASK(11, 9)
+ #define ADS1015_CFG_MUX_MASK	GENMASK(14, 12)
++#define ADS1015_CFG_OS_MASK BIT(15)
+ 
+ /* Comparator queue and disable field */
+ #define ADS1015_CFG_COMP_DISABLE	3
+@@ -366,6 +368,8 @@ int ads1015_get_adc_result(struct ads101
+ 
+ 	cfg = (old & ~mask) | (cfg & mask);
+ 	if (old != cfg) {
++        cfg &= ~ADS1015_CFG_MOD_MASK;
++        cfg |= ADS1015_CFG_OS_MASK;
+ 		ret = regmap_write(data->regmap, ADS1015_CFG_REG, cfg);
+ 		if (ret)
+ 			return ret;
+@@ -375,8 +379,8 @@ int ads1015_get_adc_result(struct ads101
  		dr_old = (old & ADS1015_CFG_DR_MASK) >> ADS1015_CFG_DR_SHIFT;
  		conv_time = DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr_old]);
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -1,0 +1,26 @@
+Description: extending duration of delay
+ This patch addresses 2 delays, influencing time of returninga latest
+ stored in register value.
+  1) instead 10% of { duration_previous + duration_latest } reworked to 20% of that time as extra await.
+  this is required as was previously shown that second consequetial reading returns @proper@ value
+  2) usleep_range now has changed upper range to make it more relaxed in firing interrupt
+Author: IFG konara@ya.ru
+Origin: upstream
+Last-Update: 2023-01-09 
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
+===================================================================
+--- linux-5.4.168.orig/drivers/iio/adc/ti-ads1015.c
++++ linux-5.4.168/drivers/iio/adc/ti-ads1015.c
+@@ -375,8 +375,8 @@ int ads1015_get_adc_result(struct ads101
+ 		dr_old = (old & ADS1015_CFG_DR_MASK) >> ADS1015_CFG_DR_SHIFT;
+ 		conv_time = DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr_old]);
+ 		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
+-		conv_time += conv_time / 10; /* 10% internal clock inaccuracy */
+-		usleep_range(conv_time, conv_time + 1);
++		conv_time += conv_time / 5; /* 20% internal clock inaccuracy */
++		usleep_range(conv_time, conv_time + conv_time/10);
+ 		data->conv_invalid = false;
+ 	}
+ 

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -29,7 +29,15 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  
  /* Comparator queue and disable field */
  #define ADS1015_CFG_COMP_DISABLE	3
-@@ -366,6 +368,8 @@ int ads1015_get_adc_result(struct ads101
+@@ -342,6 +344,7 @@ int ads1015_get_adc_result(struct ads101
+ 	int ret, pga, dr, dr_old, conv_time;
+ 	unsigned int old, mask, cfg;
+ 
++printk("entered ads1015_get_adc_result with chan =%d", chan);
+ 	if (chan < 0 || chan >= ADS1015_CHANNELS)
+ 		return -EINVAL;
+ 
+@@ -366,6 +369,8 @@ int ads1015_get_adc_result(struct ads101
  
  	cfg = (old & ~mask) | (cfg & mask);
  	if (old != cfg) {
@@ -38,7 +46,7 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  		ret = regmap_write(data->regmap, ADS1015_CFG_REG, cfg);
  		if (ret)
  			return ret;
-@@ -375,8 +379,9 @@ int ads1015_get_adc_result(struct ads101
+@@ -375,11 +380,15 @@ int ads1015_get_adc_result(struct ads101
  		dr_old = (old & ADS1015_CFG_DR_MASK) >> ADS1015_CFG_DR_SHIFT;
  		conv_time = DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr_old]);
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
@@ -46,7 +54,13 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
 -		usleep_range(conv_time, conv_time + 1);
 +		conv_time += conv_time / 5 ; /* 20% internal clock inaccuracy */
 +		conv_time = DIV_ROUND_UP(conv_time, USEC_PER_MSEC);
++printk("before msleep with conv_time=%d", conv_time);
 +		msleep(conv_time);
++printk("after sleep");
  		data->conv_invalid = false;
  	}
+ 
++printk("right before exit from adc_get_Result");
+ 	return regmap_read(data->regmap, ADS1015_CONV_REG, val);
+ }
  

--- a/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
+++ b/target/linux/imx6ull/patches-5.4/440_extend_ads115_delay.patch
@@ -44,7 +44,7 @@ Index: linux-5.4.168/drivers/iio/adc/ti-ads1015.c
  		conv_time += DIV_ROUND_UP(USEC_PER_SEC, data->data_rate[dr]);
 -		conv_time += conv_time / 10; /* 10% internal clock inaccuracy */
 -		usleep_range(conv_time, conv_time + 1);
-+		conv_time += conv_time / 10; /* 50% internal clock inaccuracy */
++		conv_time += conv_time / 5 ; /* 20% internal clock inaccuracy */
 +		conv_time = DIV_ROUND_UP(conv_time, USEC_PER_MSEC);
 +		msleep(conv_time);
  		data->conv_invalid = false;


### PR DESCRIPTION
These changes addresses opportunity to get accurate reading from ADC in cases when several channels are queried in undetermined fashion.
Reaching the goal is done by making bigger delay with respect to original version.
Thus, using this patch leads to accurate readings at the cost of more durable first reading on "just switched on" channel.
