### PR TITLE
compile time warnings fixes

### DIFF
--- a/package/gs/gs/Makefile
+++ b/package/gs/gs/Makefile
@@ -33,6 +33,7 @@ define Package/gs/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gs $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/test_modbus $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/test_modbus2 $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/test_can $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) ./files/gpio_conf.json $(1)/etc/gpio_conf.json
 	$(INSTALL_DIR) $(1)/etc/gs

--- a/package/gs/gs/src/Makefile
+++ b/package/gs/gs/src/Makefile
@@ -1,4 +1,4 @@
-all: gs test_modbus test_modbus2
+all: gs test_modbus test_modbus2 test_can
 
 CC = gcc
 CFLAGS += -Wall -Wunused -std=c11
@@ -22,7 +22,10 @@ test_modbus: $(OBJ)
 test_modbus2: $(OBJ)
 	$(CC) -o test_modbus2 test_modbus2.o $(LDFLAGS)
 
+test_can: test_can.o can.o settings.o
+	$(CC) -o  $@ $? $(CFLAGS) $(LDFLAGS)
+
 .PHONY: clean
 
 clean:
-	rm -f gs test_modbus *.o
+	rm -f gs test_modbus test_can *.o

--- a/package/gs/gs/src/buttons.c
+++ b/package/gs/gs/src/buttons.c
@@ -29,7 +29,7 @@ void buttons_init(rk_t* left, rk_t* right){
     callback1 = left->btn_clbk_stop;
     callback2 = right->btn_clbk_start;
     callback3 = right->btn_clbk_stop;
-    return 0;
+    return;
 }
 
 int buttons_handler(rk_t* left, rk_t* right){

--- a/package/gs/gs/src/can.c
+++ b/package/gs/gs/src/can.c
@@ -10,6 +10,7 @@ static int CAN_send_price_only(can_t* self, float totalPrice);
 int CAN_init(int idx, can_t* can) {
 
     char filename[FILENAME_MAX_SIZE];
+    int busNumber, deviceAddr;
 
     // busNumber
     memset(filename, 0, FILENAME_MAX_SIZE);
@@ -20,15 +21,7 @@ int CAN_init(int idx, can_t* can) {
     if(ret == -1) {
         return -1;
     }
-    can->busNumber = ret;
-
-    sprintf(can->bus, "can%d", can->busNumber);
-
-    can->fd = CAN_socket_init(can->bus);
-
-    if(can->fd == -1) {
-        return -1;
-    }
+    busNumber = ret;
 
     // deviceBaseAddress
     memset(filename, 0, FILENAME_MAX_SIZE);
@@ -40,11 +33,30 @@ int CAN_init(int idx, can_t* can) {
     if(ret == -1) {
         return -1;
     }
-    can->deviceAddress = ret;
+    deviceAddr = ret;
+
+    return CAN_init_ex(can, busNumber, deviceAddr);
+}
+
+int CAN_init_ex( can_t* can, const int busNum, const int da)
+{
+    can->busNumber = busNum;
+
+    sprintf(can->bus, "can%d", can->busNumber);
+
+    can->fd = CAN_socket_init(can->bus);
+
+    if(can->fd == -1) {
+        return -1;
+    }
+
+    can->deviceAddress = da;
 
     can->transmit = CAN_send;
     can->transmit_half = CAN_send_half;
     can->transmit_price_only = CAN_send_price_only;
+
+    return 0;
 }
 
 static int CAN_socket_init(char* interface) {

--- a/package/gs/gs/src/can.h
+++ b/package/gs/gs/src/can.h
@@ -28,7 +28,7 @@ typedef struct can_t can_t;
 
 struct can_t {
     int busNumber;
-    char bus[4];
+    char bus[20];
     int deviceAddress;
     char config_filename_bus_number[CONFIG_FILENAME_MAX_LENGTH];
     char config_filename_device_address[CONFIG_FILENAME_MAX_LENGTH];
@@ -46,5 +46,6 @@ struct can_t {
 #define CONFIG_FILE_CAN_DEVICE_ADDRESS              "/mnt/gs/%d/can_deviceAddress"
 
 int CAN_init(int idx, can_t* can);
+int CAN_init_ex(can_t* can, int, int);
 
 #endif  // CAN_H

--- a/package/gs/gs/src/in_4_20_ma.c
+++ b/package/gs/gs/src/in_4_20_ma.c
@@ -115,7 +115,8 @@ int in_4_20_ma_read_thread(in_4_20_t* in_4_20) {
     }
 }
 
-int in_4_20_ma_read_thread_both(struct in_4_20_t**  in_4_20s) {
+void * in_4_20_ma_read_thread_both(void * arg) {
+    struct in_4_20_t ** in_4_20s = (struct in_4_20_t**)arg;
 	int ret_right_1 = 0;
 	int ret_right_2 = 0;
 	int ret_left_1 = 0;
@@ -155,6 +156,7 @@ int in_4_20_ma_read_thread_both(struct in_4_20_t**  in_4_20s) {
     	}
 #endif
     }
+    return NULL;
 }
 
 

--- a/package/gs/gs/src/in_4_20_ma.h
+++ b/package/gs/gs/src/in_4_20_ma.h
@@ -67,7 +67,7 @@ struct in_4_20_t {
 
 int in_4_20_ma_init(int idx, in_4_20_t* in_4_20, int enabled);
 int in_4_20_ma_read(in_4_20_t* in_4_20);
-int in_4_20_ma_read_thread_both(struct in_4_20_t**  in_4_20s);
+void* in_4_20_ma_read_thread_both(void *arg);
 int in_4_20_ma_check_state(in_4_20_t* in_4_20);
 float in_4_20_ma_convert_raw_to_ma(int value);
 float in_4_20_ma_convert_ma_to_raw(float value);

--- a/package/gs/gs/src/led.c
+++ b/package/gs/gs/src/led.c
@@ -3,7 +3,7 @@
 #define FILENAME_MAX_SIZE   64
 #define RX_BUF_SIZE         64
 
-static int led_indicate_thread(led_t* led);
+static void * led_indicate_thread(void* arg);
 
 int led_init(int idx, led_t* led, int32_t* error_flag, int* normal_flag) {
 
@@ -86,7 +86,8 @@ int led_init(int idx, led_t* led, int32_t* error_flag, int* normal_flag) {
     return 0;
 }
 
-static int led_indicate_thread(led_t* led) {
+static void * led_indicate_thread(void* arg) {
+    led_t * led = (led_t*)arg;
 //	printf("LED NORMAL gpio filename: %s\r\n", led->normal_led_filename);
 //	printf("LED ERROR gpio filename: %s\r\n", led->error_led_filename);
     while(1) {

--- a/package/gs/gs/src/libazt.c
+++ b/package/gs/gs/src/libazt.c
@@ -5,11 +5,11 @@
 void azt_request_parser(char* rx_buf, int rx_buf_len);
 static int azt_calculate_address(char* rx_buf, int starting_symbol_idx);
 static int azt_validate_complimentary_bytes(char* rx_buf, int starting_symbol_idx, int ending_symbol_idx);
-static azt_validate_crc(char* rx_buf, int starting_symbol_idx, int ending_symbol_idx, int crc_symbol_idx);
+static int azt_validate_crc(char* rx_buf, int starting_symbol_idx, int ending_symbol_idx, int crc_symbol_idx);
 static int azt_calculate_crc(char* buf, int starting_symbol_idx, int ending_symbol_idx);
 static void azt_req_extract(azt_request_t* azt_req, char* rx_buf, int azt_request_cmd_idx, int ending_symbol_idx, int address);
-static azt_reqs_clean(void);
-static azt_req_clean(azt_request_t* req);
+static void azt_reqs_clean(void);
+static void azt_req_clean(azt_request_t* req);
 int azt_request_parser_sub(char* rx_buf, int rx_buf_len, int *idx);
 
 char azt_request_params[AZT_REQUEST_PARAMS_MAX_AMOUNT] = {0};
@@ -252,14 +252,14 @@ int azt_tx(char* data, int cnt) {
 //////////////////////////////////////////////////////////////////////////////////////
 /////////// local functions  /////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
-static azt_reqs_clean(void) {
+static void azt_reqs_clean(void) {
 	for(int i=0; i<AZT_REQUESTS_BUF_SIZE; i++) {
 		azt_req_clean(azt_reqs+i);
 	}
 	azt_reqs_cnt = 0;
 }
 
-static azt_req_clean(azt_request_t* req) {
+static void azt_req_clean(azt_request_t* req) {
     req->cmd = 0;
     req->params_cnt = 0;
     memset(req->params, 0, AZT_REQUEST_PARAMS_MAX_AMOUNT);
@@ -321,7 +321,7 @@ static int azt_validate_complimentary_bytes(char* rx_buf, int starting_symbol_id
     return 0;
 }
 
-static azt_validate_crc(char* rx_buf, int starting_symbol_idx, int ending_symbol_idx, int crc_symbol_idx) {
+static int azt_validate_crc(char* rx_buf, int starting_symbol_idx, int ending_symbol_idx, int crc_symbol_idx) {
     int res = 0;
     for(int i=starting_symbol_idx+1; i<=ending_symbol_idx; i+=2) {
         res ^= rx_buf[i];

--- a/package/gs/gs/src/libgs.c
+++ b/package/gs/gs/src/libgs.c
@@ -3,7 +3,7 @@
 #define FILENAME_MAX_SIZE   64
 #define RX_BUF_SIZE         64
 
-static void gs_thread(gs_conninfo_t* conninfo);
+static void *gs_thread(void *);
 
 static int gs_read_reg(modbus_t *ctx, int reg, int count, uint16_t *buffer)
 {
@@ -36,7 +36,7 @@ int gs_set_modbus_baudrate(gs_conninfo_t* conninfo, Flomac_Baudrate_t baudrate_)
 
     modbus_t *ctx = conninfo->ctx;
 
-    if (gs_read_reg(ctx, R_MMI_MBUS_MAP, 1, &device_mode) == -1)
+    if (gs_read_reg(ctx, R_MMI_MBUS_MAP, 1, (uint16_t *) &device_mode) == -1)
     {
         return -1;
     }
@@ -47,14 +47,14 @@ int gs_set_modbus_baudrate(gs_conninfo_t* conninfo, Flomac_Baudrate_t baudrate_)
 
     	printf("Baudrate changing step 1. set Flomac mode\r\n");
     	// change mode from MMI to Flomac
-    	if(gs_write_reg(ctx, R_MMI_MBUS_MAP, 1, &mode) == -1) {
+    	if(gs_write_reg(ctx, R_MMI_MBUS_MAP, 1, (uint16_t*)&mode) == -1) {
     		printf("MB error. write failed\r\n");
     	}
     }
 
     printf("Baudrate changing step 2. set baudrate\r\n");
     // set Baudrate
-    if(gs_write_reg(ctx, REG_F_BAUDRATE, 1, &baudrate) == -1) {
+    if(gs_write_reg(ctx, REG_F_BAUDRATE, 1, (uint16_t *)&baudrate) == -1) {
     	printf("MB error. write failed\r\n");
     }
 
@@ -80,7 +80,7 @@ int gs_set_modbus_baudrate(gs_conninfo_t* conninfo, Flomac_Baudrate_t baudrate_)
     	// change mode back from Flomac to MMI
     	int mode = Mode_MMI;
     	usleep(100000);
-    	if(gs_write_reg(ctx, R_MMI_MBUS_MAP, 1, &mode) == -1) {
+    	if(gs_write_reg(ctx, R_MMI_MBUS_MAP, 1, (uint16_t*) &mode) == -1) {
     	}
     	usleep(100000);
     }
@@ -95,12 +95,12 @@ int gs_get_version(modbus_t *ctx)
     int device_mode = 0;
     int sw_revision = 0;
 
-    if (gs_read_reg(ctx, R_MMI_MBUS_MAP, 1, &device_mode) == -1)
+    if (gs_read_reg(ctx, R_MMI_MBUS_MAP, 1, (uint16_t*) &device_mode) == -1)
     {
         return -1;
     }
 
-    if (gs_read_reg(ctx, R_MMI_SW_VER, 1, &sw_revision) == -1)
+    if (gs_read_reg(ctx, R_MMI_SW_VER, 1, (uint16_t*) &sw_revision) == -1)
     {
         return -1;
     }
@@ -152,7 +152,7 @@ int gs_get_all_units(modbus_t *ctx, measure_units_t *measure_units)
 
     uint16_t buf[8];
     p = (uint16_t *)measure_units;
-    if (gs_read_reg(ctx, R_MMI_UNITS_BASE, 8, &buf) == -1)
+    if (gs_read_reg(ctx, R_MMI_UNITS_BASE, 8, &buf[0]) == -1)
         return -1;
     for (int i = 0; i < 8; i++)
     {
@@ -162,6 +162,9 @@ int gs_get_all_units(modbus_t *ctx, measure_units_t *measure_units)
 
     return 0;
 }
+
+// forward declaration
+int gs_get_mass_summator_only(modbus_t *, measurements_t *);
 
 int gs_get_measurements(modbus_t *ctx, measurements_t *measurements, int* counter)
 {
@@ -184,7 +187,7 @@ int gs_get_all_measurements(modbus_t *ctx, measurements_t *measurements)
     float *p;
     p = (float *)measurements;
     uint16_t buf[20];
-    if (gs_read_reg(ctx, R_MMI_MEASUREMENTS_BASE, 20, &buf) == -1) {
+    if (gs_read_reg(ctx, R_MMI_MEASUREMENTS_BASE, 20, buf) == -1) {
         return -1;
     }
     for (int i = 0; i < 20; i += 2)
@@ -201,7 +204,7 @@ int gs_get_mass_summator_only(modbus_t *ctx, measurements_t *measurements)
     p = (float *)measurements;
     p = p+9;
     uint16_t buf[2];
-    if (gs_read_reg(ctx, R_MMI_DENSITY, 2, &buf) == -1) {
+    if (gs_read_reg(ctx, R_MMI_DENSITY, 2, buf) == -1) {
         return -1;
     }
     for (int i = 0; i < 2; i += 2)
@@ -216,7 +219,7 @@ int gs_set_mass_units(modbus_t *ctx, int mass_units)
 {
     uint8_t ret;
     uint16_t readback_value;
-    ret = modbus_write_and_read_registers(ctx, R_MMI_MASS_U, 1, &mass_units,
+    ret = modbus_write_and_read_registers(ctx, R_MMI_MASS_U, 1, (uint16_t*)&mass_units,
                                           R_MMI_MASS_U, 1, &readback_value);
     if ((mass_units == readback_value) || !ret)
         return 0;
@@ -228,7 +231,7 @@ int gs_set_volume_units(modbus_t *ctx, int volume_units)
 {
     uint8_t ret;
     uint16_t readback_value;
-    ret = modbus_write_and_read_registers(ctx, R_MMI_VOLUME_U, 1, &volume_units,
+    ret = modbus_write_and_read_registers(ctx, R_MMI_VOLUME_U, 1, (uint16_t*) &volume_units,
                                           R_MMI_VOLUME_U, 1, &readback_value);
     if ((volume_units == readback_value) || !ret)
         return 0;
@@ -322,7 +325,8 @@ V_TOTAL: %.2f. M_INV: %.2f. V_INV: %.2f\r\n",
 }
 
 
-static void gs_thread(gs_conninfo_t* conninfo) {
+static void *gs_thread(void* arg) {
+gs_conninfo_t* conninfo = (gs_conninfo_t*) arg;
     int ret;
     _Atomic float* mass = (_Atomic float*)&conninfo->summator_mass;
     _Atomic float* mass_flowrate = (_Atomic float*)&conninfo->mass_flowrate;
@@ -374,6 +378,7 @@ static void gs_thread(gs_conninfo_t* conninfo) {
             atomic_store(mass_flowrate, conninfo->measurements.mass_flowrate);
         }
     }
+    return NULL;
 }
 
 int gs_check_state(gs_conninfo_t* conninfo) {
@@ -384,10 +389,10 @@ modbus_t *gs_init(gs_conninfo_t *conninfo)
 {
     modbus_t *ctx;
     int ret;
-    char port[16];
+    char port[60];
 
     conninfo->measurements_read_counter = 0;
-    sprintf(&port, "/dev/ttymxc%d", conninfo->port);
+    sprintf(port, "/dev/ttymxc%d", conninfo->port);
 //    printf("Connecting to %s...\n", port);
 //    printf("Connecting using baudrate: %d\n", conninfo->baudrate);
     ctx = modbus_new_rtu(port, conninfo->baudrate, 'N', 8, 1);

--- a/package/gs/gs/src/libgs.h
+++ b/package/gs/gs/src/libgs.h
@@ -63,7 +63,7 @@ typedef struct gs_conninfo {
 } gs_conninfo_t;
 
 /* port handling */
-//int gs_init_pthreaded(int idx, gs_conninfo_t *conninfo);
+int gs_init_pthreaded(int idx, gs_conninfo_t *conninfo);
 modbus_t* gs_init(gs_conninfo_t *conninfo);
 int gs_scan_ext(gs_conninfo_t *conninfo, int maxAddrModBUS);
 int gs_scan(gs_conninfo_t *conninfo);

--- a/package/gs/gs/src/libgs.h
+++ b/package/gs/gs/src/libgs.h
@@ -65,6 +65,7 @@ typedef struct gs_conninfo {
 /* port handling */
 //int gs_init_pthreaded(int idx, gs_conninfo_t *conninfo);
 modbus_t* gs_init(gs_conninfo_t *conninfo);
+int gs_scan_ext(gs_conninfo_t *conninfo, int maxAddrModBUS);
 int gs_scan(gs_conninfo_t *conninfo);
 void gs_close(modbus_t *ctx);
 int gs_check_state(gs_conninfo_t* conninfo);

--- a/package/gs/gs/src/rk.h
+++ b/package/gs/gs/src/rk.h
@@ -104,8 +104,8 @@ struct rk_t {
     in_4_20_t in_4_20;
     error_t error_state;
     gs_conninfo_t modbus;
-    void (*btn_clbk_start)(int);
-    void (*btn_clbk_stop)(int);
+    void (*btn_clbk_start)(rk_t*, int);
+    void (*btn_clbk_stop)(rk_t*, int);
     int stop_button_pressed_flag;
     int start_button_pressed_flag;
     int start_button_delay_cnt;

--- a/package/gs/gs/src/settings.c
+++ b/package/gs/gs/src/settings.c
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include <unistd.h>
 
 #define RX_BUF_SIZE         64
 

--- a/package/gs/gs/src/test_can.c
+++ b/package/gs/gs/src/test_can.c
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <termios.h>
+
+#include "can.h"
+
+void print_help()
+{
+    printf("usage: app [-a {0 | 1 } ] [-h] \n");
+}
+
+struct triplet {
+    const float vol;
+    const float pr;
+    const float totPr;
+};
+
+int main(int argc, char* argv[])
+{
+    int ret;
+    int addr=0, addr_c, opt;
+    int delay = 1000, delay_c;
+
+
+    while ((opt = getopt(argc, argv, "ha:d:")) != -1)
+    {
+        switch (opt) {
+               case 'h':
+                    print_help();
+                    exit(EXIT_SUCCESS);
+               case 'a':
+                   addr_c = atoi(optarg);
+                    if(addr_c == 0 || addr_c == 1)
+                        addr = addr_c;
+                   break;
+                case 'd':
+                    delay_c = atoi(optarg);
+                    if( delay_c > 20 && delay_c < 30000)
+                        delay = delay_c;
+                    break;
+               default: /* '?' */
+                   fprintf(stderr, "Usage: %s [-a {0 |1}] [-h]\n",
+                           argv[0]);
+                   exit(EXIT_FAILURE);
+               }
+    }
+
+    int addr_base;
+    switch(addr)
+    {
+        case 1:
+            addr_base = 0x40;
+            break;
+        default:
+            addr_base = 0x20;
+
+    };
+
+    can_t canNet;
+
+    if( CAN_init_ex(&canNet, 0, addr_base) != 0)
+    {
+        fprintf(stderr, "failed to execute CAN_init_ex for %d\n", addr_base);
+        exit(EXIT_FAILURE);
+    }
+
+struct triplet _records[] =
+{
+    {0.00f, 0.00f, 0.00f},
+    {1111.11f, 1111.11f, 1111.11f},
+    {2222.22f, 2222.22f, 2222.22f},
+    {3333.33f, 3333.33f, 3333.33f},
+    {4444.44f, 4444.44f, 4444.44f},
+    {5555.55f, 5555.55f, 5555.55f},
+    {6666.66f, 6666.66f, 6666.66f},
+    {7777.77f, 7777.77f, 7777.77f},
+    {8888.88f, 8888.88f, 8888.88f},
+    {9999.99f, 9999.99f, 9999.99f},
+
+    {110000.00f, 0.00f, 110000.00f},
+    {220000.00f, 0.00f, 220000.00f},
+    {330000.00f, 0.00f, 330000.00f},
+    {440000.00f, 0.00f, 440000.00f},
+    {550000.00f, 0.00f, 550000.00f},
+    {660000.00f, 0.00f, 660000.00f},
+    {770000.00f, 0.00f, 770000.00f},
+    {880000.00f, 0.00f, 880000.00f},
+    {990000.00f, 0.00f, 990000.00f},
+
+    {0.00f, 0.00f, 0.00f},
+};
+
+    int nxt = 0;
+    while(1)
+    {
+        canNet.transmit(&canNet, _records[nxt].vol, _records[nxt].pr, _records[nxt].totPr);
+        usleep(1000 * delay);
+        ++nxt; nxt %= (sizeof(_records)/sizeof(struct triplet));
+    }
+    
+    close(canNet.fd);
+    exit(EXIT_SUCCESS);
+}
+

--- a/package/gs/gs/src/test_modbus.c
+++ b/package/gs/gs/src/test_modbus.c
@@ -5,11 +5,16 @@
 #include <unistd.h>
 #include <errno.h>
 #include <termios.h>
+#include <stdlib.h>
 
 //#include "libgs.h"
 #include "libazt.h"
 #include "rk.h"
 #include "buttons.h"
+
+#define DEFAULT_MAX_SCAN_ADDR 3
+#define DEFAULT_BAUD_RATE B9600
+
 
 // 1st inst
 gs_conninfo_t gs1_conn =
@@ -27,14 +32,56 @@ gs_conninfo_t gs2_conn =
 	.devaddr = DEF_ADDR
 };
 
+int print_help()
+{
+    printf("Calling conversion:\n");
+    printf("test_modbus [-a 3] [-b 9600] [-h]\n");
+    printf("Where:\n");
+    printf("\t-a max_addr \t\tset maximal address used while scanning (default is 3)\n");
+    printf("\t-b baudrate \t\tset baudrate of communication. Supported bauds are 9600, 19200, 38400, 57600, 115200. 9600 is default\n");
+    printf("\t-h          \t\t prints this help and exits\n");
+    return 0;
+};
+
 int main(int argc, char* argv[])
 {
     int ret;
 	modbus_t *ctx;
-    ret = gs_scan(&gs2_conn);
+    int max_addr = DEFAULT_MAX_SCAN_ADDR, a_cand;
+    int baud = DEFAULT_BAUD_RATE, b_cand;
+
+    int opt;
+
+    while ((opt = getopt(argc, argv, "ha:b:")) != -1) {
+        switch(opt)
+        {
+            case 'h':
+                print_help();
+                exit(EXIT_SUCCESS);
+            case 'a':
+                a_cand = atoi(optarg);
+                if(a_cand > 0 && a_cand <= 247)
+                    max_addr = a_cand;
+                break;
+            case 'b':
+                b_cand = atoi(optarg);
+                if ( (b_cand == B9600)  || (b_cand == B19200) || ( b_cand == B38400 ) 
+                    || (b_cand == B57600 ) || (b_cand == B115200) )
+                    baud = b_cand;
+                break;
+            default:
+                print_help();
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    gs1_conn.baudrate = baud;
+    gs2_conn.baudrate = baud;
+
+    ret = gs_scan_ext(&gs2_conn, max_addr);
     printf("gs2_conninfo discovered slave device address: %d\r\n", ret);
 
-    ret = gs_scan(&gs1_conn);
+    ret = gs_scan_ext(&gs1_conn, max_addr);
     printf("gs1_conninfo discovered slave device address: %d\r\n", ret);
 	return 0;
 }

--- a/package/gs/gs/src/test_modbus2.c
+++ b/package/gs/gs/src/test_modbus2.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <termios.h>
+#include <stdlib.h>
 
 //#include "libgs.h"
 //#include "libazt.h"
@@ -31,9 +32,9 @@ char read_buf2[5] = {0};
 char read_buf3[5] = {0};
 char read_buf5[5] = {0};
 
-void init(int fd);
+int init(int fd);
 
-int read_ttymxc6(void) {
+void * read_ttymxc6(__attribute__ ((unused)) void * _) {
 	memset(read_buf6, 0, sizeof(read_buf6));
 	while(1) {
 		int ret = read(fd6, &read_buf6, sizeof(read_buf6));
@@ -44,9 +45,10 @@ int read_ttymxc6(void) {
 		}
 		}
 	}
+    return NULL;
 }
 
-int read_ttymxc5(void) {
+void * read_ttymxc5(__attribute__ ((unused))  void * _) {
 	memset(read_buf5, 0, sizeof(read_buf5));
 	while(1) {
 		int ret = read(fd5, &read_buf5, sizeof(read_buf5));
@@ -57,6 +59,7 @@ int read_ttymxc5(void) {
 		}
 		}
 	}
+    return NULL;
 }
 
 int main(int argc, char* argv[])
@@ -122,7 +125,7 @@ int main(int argc, char* argv[])
 }
 	
 
-void init(int fd) {
+int init(int fd) {
     struct termios tty;
     if (tcgetattr(fd, &tty) != 0) {
         printf("Error %i from tcgetattr: %s\n", errno, strerror(errno));
@@ -161,4 +164,5 @@ void init(int fd) {
         return 1;
     }
 
+    return 0;
 }


### PR DESCRIPTION
proper functions prototyping
proper return values of functions (and declaration of functions)

for accurate comparison obesrve output of

make -j1 V=sc package/gs/gs/clean
make -j1 V=cs package/gs/gs/compile

with these changes and without these changes compile time warnings fixes

